### PR TITLE
remove type: object from status subresource

### DIFF
--- a/deploy/crds/operator.ibm.com_helmrepos_crd.yaml
+++ b/deploy/crds/operator.ibm.com_helmrepos_crd.yaml
@@ -173,7 +173,6 @@ spec:
                 name:
                   type: string
               type: object
-          type: object
       required:
       - metadata
       - spec     


### PR DESCRIPTION
travis error message: "Example:(*apiextensions.JSON)(nil)}: must only have "properties", "required" or "description" at the root if the status subresource is enabled"